### PR TITLE
Fix armcc HardFault_Handler reset

### DIFF
--- a/bare-metal/event.c
+++ b/bare-metal/event.c
@@ -274,7 +274,7 @@ int eventOS_scheduler_timer_synch_after_sleep(uint32_t sleep_ticks)
  * Function Read and handle Cores Event and switch/enable tasklet which are event receiver. WhenEvent queue is empty it goes to sleep
  *
  */
-void event_dispatch_cycle(void)
+bool event_dispatch_cycle(void)
 {
     arm_core_tasklet_list_s *tasklet;
     arm_core_event_s *cur_event;
@@ -294,9 +294,15 @@ void event_dispatch_cycle(void)
             /* Set Current Tasklet to Idle state */
             curr_tasklet = 0;
         }
+        return true;
     } else {
-        eventOS_scheduler_idle();
+        return false;
     }
+}
+
+void eventOS_scheduler_run_until_idle(void)
+{
+    while (event_dispatch_cycle());
 }
 
 /**

--- a/bare-metal/timeout.c
+++ b/bare-metal/timeout.c
@@ -55,6 +55,8 @@ static void timeout_tasklet(arm_event_s *event)
 
 timeout_t *eventOS_timeout_ms(void (*callback)(void *), uint32_t ms, void *arg)
 {
+    uint16_t count;
+    uint8_t index;
     timeout_t *e = ns_dyn_mem_alloc(sizeof(timeout_t));
     if (!e) {
         return NULL;
@@ -72,13 +74,13 @@ timeout_t *eventOS_timeout_ms(void (*callback)(void *), uint32_t ms, void *arg)
     }
 
     // Check that we still have indexes left. We have only 8bit timer id.
-    uint16_t count = ns_list_count(&timeout_list);
+    count = ns_list_count(&timeout_list);
     if (count >= UINT8_MAX) { // Too big list, timer_id is uint8_t
         goto FAIL;
     }
 
     // Find next free index
-    uint8_t index = 0;
+    index = 0;
 AGAIN:
     ns_list_foreach(timeout_t, cur, &timeout_list) {
         if (cur->event_id == index) { // This index was used

--- a/nanostack-event-loop/eventOS_scheduler.h
+++ b/nanostack-event-loop/eventOS_scheduler.h
@@ -26,6 +26,11 @@ extern "C" {
  */
 extern void eventOS_scheduler_init(void);
 /**
+ * \brief Process events until no more events to process.
+ *
+ */
+extern void eventOS_scheduler_run_until_idle(void);
+/**
  * \brief Start Event scheduler.
  *
  */

--- a/source/event.cpp
+++ b/source/event.cpp
@@ -13,14 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- * \file event.c
- * \brief Core event handler.
- *
- *  Event dispatching functions.
- *
- */
 #include <string.h>
 #include "ns_types.h"
 #include "ns_list.h"
@@ -214,7 +206,7 @@ void event_core_write(arm_core_event_s *event)
     }
 
     if (!run_scheduled) {
-        Scheduler::postCallback(FunctionPointer0<void>(eventOS_scheduler_run).bind()).tolerance(0);
+        Scheduler::postCallback(FunctionPointer0<void>(eventOS_scheduler_run_until_idle).bind()).tolerance(0);
         run_scheduled = true;
     }
 
@@ -318,6 +310,12 @@ bool event_dispatch_cycle(void)
     }
 }
 
+void eventOS_scheduler_run_until_idle(void)
+{
+    while (event_dispatch_cycle());
+    run_scheduled = false;
+}
+
 /**
  *
  * \brief Infinite Event Read Loop.
@@ -327,6 +325,7 @@ bool event_dispatch_cycle(void)
  */
 noreturn void eventOS_scheduler_run(void)
 {
-    while (event_dispatch_cycle());
-    run_scheduled = false;
+    while (1) {
+        event_dispatch_cycle();
+    }
 }


### PR DESCRIPTION
Remove noreturn statement from eventOS_scheduler_run() as it
has been changed to be a returning function.

This commit will fix ONME-1673.

@kjbracey-arm , @SeppoTakalo , would you please review the change?