### PR TITLE
Fixes for NS_NORETURN

### DIFF
--- a/nanostack-event-loop/eventOS_scheduler.h
+++ b/nanostack-event-loop/eventOS_scheduler.h
@@ -50,7 +50,7 @@ extern void eventOS_scheduler_run_until_idle(void);
  * Loops forever processing events from the queue.
  * Calls eventOS_scheduler_idle() whenever event queue is empty.
  */
-extern NS_NORETURN void eventOS_scheduler_run(void);
+NS_NORETURN extern void eventOS_scheduler_run(void);
 /**
  * \brief Disable Event scheduler Timers
  *

--- a/source/event.cpp
+++ b/source/event.cpp
@@ -323,7 +323,7 @@ void eventOS_scheduler_run_until_idle(void)
  * Function Read and handle Cores Event and switch/enable tasklet which are event receiver. WhenEvent queue is empty it goes to sleep
  *
  */
-noreturn void eventOS_scheduler_run(void)
+NS_NORETURN void eventOS_scheduler_run(void)
 {
     while (1) {
         if (!eventOS_scheduler_dispatch_event()) {


### PR DESCRIPTION
1. NS_NORETURN missing from event.cpp
2. Changed order of 'extern' and 'NS_NORETURN' to get rid of this
compiler warning:

/home/bogdanm/work/armmbed/projects/techcon-release/c++11/mbed-mesh-api/yotta_modules/nanostack-libservice/mbed-client-libservice/ns_types.h:104:21:
warning: attribute ignored [-Wattributes]
 #define NS_NORETURN [[noreturn]]
                     ^
/home/bogdanm/work/armmbed/projects/techcon-release/c++11/mbed-mesh-api/yotta_modules/sal-stack-nanostack-eventloop/nanostack-event-loop/eventOS_scheduler.h:53:8:
note: in expansion of macro 'NS_NORETURN'
 extern NS_NORETURN void eventOS_scheduler_run(void);
        ^
/home/bogdanm/work/armmbed/projects/techcon-release/c++11/mbed-mesh-api/yotta_modules/nanostack-libservice/mbed-client-libservice/ns_types.h:104:21:
note: an attribute that appertains to a type-specifier is ignored
 #define NS_NORETURN [[noreturn]]
                     ^
/home/bogdanm/work/armmbed/projects/techcon-release/c++11/mbed-mesh-api/yotta_modules/sal-stack-nanostack-eventloop/nanostack-event-loop/eventOS_scheduler.h:53:8:
note: in expansion of macro 'NS_NORETURN'
 extern NS_NORETURN void eventOS_scheduler_run(void);