### PR TITLE
Timers in hold state must be recalculated in timer stop handler.

### DIFF
--- a/bare-metal/ns_timer.c
+++ b/bare-metal/ns_timer.c
@@ -374,6 +374,8 @@ int8_t eventOS_callback_timer_stop(int8_t ns_timer_id)
                 if (current_timer->timer_state == NS_TIMER_HOLD) {
                     if (current_timer->remaining_slots == first_timer->remaining_slots) {
                         current_timer->timer_state = NS_TIMER_ACTIVE;
+                    } else {
+                        current_timer->remaining_slots -= first_timer->remaining_slots;
                     }
                 }
             }


### PR DESCRIPTION
This bug was causing randomly too long timeouts.