### PR TITLE
Signal event to platform outside critical section

### DIFF
--- a/bare-metal/event.c
+++ b/bare-metal/event.c
@@ -201,8 +201,8 @@ void event_core_write(arm_core_event_s *event)
     }
 
     /* Wake From Idle */
-    eventOS_scheduler_signal();
     platform_exit_critical();
+    eventOS_scheduler_signal();
 }
 
 /**

--- a/source/event.c
+++ b/source/event.c
@@ -201,8 +201,8 @@ void event_core_write(arm_core_event_s *event)
     }
 
     /* Wake From Idle */
-    eventOS_scheduler_signal();
     platform_exit_critical();
+    eventOS_scheduler_signal();
 }
 
 /**


### PR DESCRIPTION
One platform requires its eventOS_scheduler_signal implementation to be
called with interrupts enabled, and as far as I can determine, no
existing platforms require them disabled.

Accordingly, leave the critical section in event_core_write() before
calling eventOS_scheduler_signal().

This also requires that event_core_write() itself never be called in a
critical section - this appears to be the case.