### PR TITLE
Add function to check if we own the mutex

### DIFF
--- a/nanostack-event-loop/eventOS_scheduler.h
+++ b/nanostack-event-loop/eventOS_scheduler.h
@@ -148,6 +148,24 @@ extern void eventOS_scheduler_mutex_wait(void);
  */
 extern void eventOS_scheduler_mutex_release(void);
 
+/**
+ * \brief Check if the current thread owns the event mutex
+ *
+ * Check if the calling thread owns the scheduler mutex.
+ * This allows the ownership to be asserted if a function
+ * requires the mutex to be locked externally.
+ *
+ * The function is only intended as a debugging aid for
+ * users of eventOS_scheduler_mutex_wait() - it is not
+ * used by the event loop core itself.
+ *
+ * If the underlying mutex system does not support it,
+ * this may be implemented to always return true.
+ *
+ * \return true if the current thread owns the mutex
+ */
+extern bool eventOS_scheduler_mutex_am_owner(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
For debugging purposes, add a prototype for
eventOS_scheduler_mutex_am_owner(). This can be useful in
asserts for correct locking in multithreaded systems.

Change-Id: Ic4b31e7da701a523e37fd9d72dd5bce67e170998
Suggested-by: Russ Butler <russ.butler@arm.com>