### PR TITLE
ONME-2971: Refine eventOS_event_timer API

### DIFF
--- a/nanostack-event-loop/eventOS_event.h
+++ b/nanostack-event-loop/eventOS_event.h
@@ -78,9 +78,12 @@ typedef struct arm_event_storage {
  */
 extern int8_t eventOS_event_send(const arm_event_t *event);
 
-/* Alternate name for timer function from eventOS_event_timer.h;
+/* Alternate names for timer function from eventOS_event_timer.h;
  * implementations may one day merge */
-#define eventOS_event_send_at(event, at) eventOS_event_timer_send(event, at)
+#define eventOS_event_send_at(event, at)       eventOS_event_timer_request_at(event, at)
+#define eventOS_event_send_in(event, in)       eventOS_event_timer_request_in(event, in)
+#define eventOS_event_send_after(event, after) eventOS_event_timer_request_after(event, after)
+#define eventOS_event_send_every(event, every) eventOS_event_timer_request_every(event, every)
 
 /**
  * \brief Send user-allocated event to event scheduler.

--- a/nanostack-event-loop/eventOS_event.h
+++ b/nanostack-event-loop/eventOS_event.h
@@ -78,6 +78,10 @@ typedef struct arm_event_storage {
  */
 extern int8_t eventOS_event_send(const arm_event_t *event);
 
+/* Alternate name for timer function from eventOS_event_timer.h;
+ * implementations may one day merge */
+#define eventOS_event_send_at(event, at) eventOS_event_timer_send(event, at)
+
 /**
  * \brief Send user-allocated event to event scheduler.
  *

--- a/nanostack-event-loop/eventOS_event_timer.h
+++ b/nanostack-event-loop/eventOS_event_timer.h
@@ -20,25 +20,102 @@ extern "C" {
 #endif
 #include "ns_types.h"
 
+struct arm_event_s;
+
+/* 100 Hz ticker, so 10 milliseconds per tick */
+#define EVENTOS_EVENT_TIMER_HZ 100
+
+static inline uint32_t eventOS_event_timer_ticks_to_ms(uint32_t ticks)
+{
+    NS_STATIC_ASSERT(1000 % EVENTOS_EVENT_TIMER_HZ == 0, "Assuming whole number of ms per tick")
+    return ticks * (1000 / EVENTOS_EVENT_TIMER_HZ);
+}
+
+static inline uint32_t eventOS_event_timer_ms_to_ticks(uint32_t ms)
+{
+    NS_STATIC_ASSERT(1000 % EVENTOS_EVENT_TIMER_HZ == 0, "Assuming whole number of ms per tick")
+    return (ms + (1000 / EVENTOS_EVENT_TIMER_HZ) - 1) / (1000 / EVENTOS_EVENT_TIMER_HZ);
+}
+
+/**
+ * Read current timer tick count.
+ *
+ * Can be used as a monotonic time source, and to schedule events with
+ * eventOS_event_timer_send.
+ *
+ * Note that the value will wrap, so take care on comparisons.
+ *
+ * \return tick count.
+ */
+extern uint32_t eventOS_event_timer_ticks(void);
+
+/* Comparison macros handling wrap efficiently (assuming a conventional compiler
+ * which converts 0x80000000 to 0xFFFFFFFF to negative when casting to int32_t).
+ */
+#define TICKS_AFTER(a, b) ((int32_t) ((a)-(b)) > 0)
+#define TICKS_BEFORE(a, b) ((int32_t) ((a)-(b)) < 0)
+#define TICKS_AFTER_OR_AT(a, b) ((int32_t) ((a)-(b)) >= 0)
+#define TICKS_BEFORE_OR_AT(a, b) ((int32_t) ((a)-(b)) <= 0)
+
 /**
  * Send an event after time expired (in milliseconds)
  *
- * \param snmessage event to send
+ * Note that the current implementation has the "feature" that rounding
+ * varies depending on the precise timing requested:
+ *     0-20 ms => 2 x 10ms tick
+ *    21-29 ms => 3 x 10ms tick
+ *    30-39 ms => 4 x 10ms tick
+ *    40-49 ms => 5 x 10ms tick
+ *    ... etc
+ *
+ * For improved flexibility on the event, and for more control of time,
+ * you should use eventOS_event_timer_request_at().
+ *
+ * \param event_id event_id for event
+ * \param event_type event_type for event
+ * \param tasklet_id receiver for event
  * \param time time to sleep in milliseconds
  *
- * \return none
+ * \return 0 on success
+ * \return -1 on error (invalid tasklet_id or allocation failure)
  *
  * */
-extern int8_t eventOS_event_timer_request(uint8_t snmessage, uint8_t event_type, int8_t tasklet_id, uint32_t time);
+extern int8_t eventOS_event_timer_request(uint8_t event_id, uint8_t event_type, int8_t tasklet_id, uint32_t time);
+
 /**
- * Cancel an event
+ * Send an event at specified time
  *
- * \param event event to cancel
+ * The event will be sent when eventOS_event_timer_ticks() reaches the
+ * specified value.
  *
- * \return none
+ * Can also be invoked using the eventOS_event_send_at() macro in eventOS_event.h
+ *
+ * \param event event to send
+ * \param at absolute tick time to run event at
+ *
+ * \return 0 on success
+ * \return -1 on error (invalid tasklet_id or allocation failure)
+ *
+ */
+extern int8_t eventOS_event_timer_send(const struct arm_event_s *event, uint32_t at);
+
+/**
+ * Cancel an event timer
+ *
+ * This cancels a pending timed event, matched by event_id and tasklet_id.
+ *
+ * Note that the current implementation can only cancel the *timer* - if the
+ * timer has expired and the event is already queued, the pending event is not
+ * cancelled.
+ *
+ * \param event_id event_id for event
+ * \param tasklet_id receiver for event
+ *
+ * \return 0 on success
+ * \return -1 on error (event not found)
  *
  * */
-extern int8_t eventOS_event_timer_cancel(uint8_t snmessage, int8_t tasklet_id);
+extern int8_t eventOS_event_timer_cancel(uint8_t event_id, int8_t tasklet_id);
 
 /**
  * System Timer shortest time in milli seconds

--- a/nanostack-event-loop/eventOS_event_timer.h
+++ b/nanostack-event-loop/eventOS_event_timer.h
@@ -191,13 +191,6 @@ extern int_fast8_t eventOS_event_timer_request_every(const struct arm_event_s *e
  *
  * This cancels a pending timed event, matched by event_id and tasklet_id.
  *
- * Note that the current implementation can only cancel the *timer* - if the
- * timer has expired and the event is already queued, the pending event is not
- * cancelled.
- *
- * If issued from within the event handler for a recurring timer, the call will
- * work.
- *
  * \param event_id event_id for event
  * \param tasklet_id receiver for event
  *

--- a/nanostack-event-loop/eventOS_event_timer.h
+++ b/nanostack-event-loop/eventOS_event_timer.h
@@ -118,7 +118,7 @@ extern int_fast8_t eventOS_event_timer_request_at(const struct arm_event_s *even
  * now. If requested just after a tick, the delay will be nearly 2 ticks, but if
  * requested just before a tick, the delay will be just over 1 tick.
  *
- * If `in` is 0, the event will be sent immediately.
+ * If `in` is <= 0, the event will be sent immediately.
  *
  * Can also be invoked using the eventOS_event_send_in() macro in eventOS_event.h
  *
@@ -129,7 +129,7 @@ extern int_fast8_t eventOS_event_timer_request_at(const struct arm_event_s *even
  * \return -1 on error (invalid tasklet_id or allocation failure)
  *
  */
-extern int_fast8_t eventOS_event_timer_request_in(const struct arm_event_s *event, uint32_t in);
+extern int_fast8_t eventOS_event_timer_request_in(const struct arm_event_s *event, int32_t in);
 
 /**
  * Send an event after a specified time
@@ -145,6 +145,9 @@ extern int_fast8_t eventOS_event_timer_request_in(const struct arm_event_s *even
  * eg requesting 2 ticks will cause the event to be sent on the third tick from
  * now. If requested just after a tick, the delay will be nearly 3 ticks, but if
  * requested just before a tick, the delay will be just over 2 ticks.
+ *
+ * If `after` is < 0, the event will be sent immediately. If it is 0, the event
+ * is sent on the next tick.
  *
  * Can also be invoked using the eventOS_event_send_after() macro in eventOS_event.h
  *
@@ -181,10 +184,10 @@ extern int_fast8_t eventOS_event_timer_request_in(const struct arm_event_s *even
  * \param period period for event
  *
  * \return 0 on success
- * \return -1 on error (invalid tasklet_id or allocation failure)
+ * \return -1 on error (invalid tasklet_id, allocation failure or non-positive period)
  *
  */
-extern int_fast8_t eventOS_event_timer_request_every(const struct arm_event_s *event, uint32_t period);
+extern int_fast8_t eventOS_event_timer_request_every(const struct arm_event_s *event, int32_t period);
 
 /**
  * Cancel an event timer

--- a/source/event.h
+++ b/source/event.h
@@ -23,6 +23,10 @@ extern "C" {
 bool event_tasklet_handler_id_valid(uint8_t tasklet_id);
 void eventOS_event_send_timer_allocated(arm_event_storage_t *event);
 
+// These require lock to be held
+arm_event_storage_t *eventOS_event_find_by_id_critical(uint8_t tasklet_id, uint8_t event_id);
+void eventOS_event_cancel_critical(arm_event_storage_t *event);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/system_timer.c
+++ b/source/system_timer.c
@@ -239,7 +239,7 @@ int_fast8_t eventOS_event_timer_request_at(const arm_event_t *event, uint32_t at
     return ret;
 }
 
-int_fast8_t eventOS_event_timer_request_in(const arm_event_t *event, uint32_t in)
+int_fast8_t eventOS_event_timer_request_in(const arm_event_t *event, int32_t in)
 {
     platform_enter_critical();
 
@@ -251,9 +251,9 @@ int_fast8_t eventOS_event_timer_request_in(const arm_event_t *event, uint32_t in
 
 }
 
-int_fast8_t eventOS_event_timer_request_every(const arm_event_t *event, uint32_t period)
+int_fast8_t eventOS_event_timer_request_every(const arm_event_t *event, int32_t period)
 {
-    if (period == 0) {
+    if (period <= 0) {
         return -1;
     }
 


### PR DESCRIPTION
Add the ability to pass a complete arm_event_t, giving full control
over the event contents.

New call also takes an absolute time, removing ambiguities and
problems with timer rounding. Caller can thus fully control their
scheduling, including the ability to maintain a fixed period
if event delivery is delayed.

Add "in", "after" and "every" versions of eventOS_event_timer_request
calls.