### PR TITLE
Tighten up configuration

### DIFF
--- a/nanostack-event-loop/platform/arm_hal_timer.h
+++ b/nanostack-event-loop/platform/arm_hal_timer.h
@@ -21,6 +21,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifndef NS_EXCLUDE_HIGHRES_TIMER
 /**
  * \brief This function perform timer init.
  */
@@ -55,6 +57,8 @@ extern void platform_timer_disable(void);
  * \return 50us time slot remaining
  */
 extern uint16_t platform_timer_get_remaining_slots(void);
+
+#endif // NS_EXCLUDE_HIGHRES_TIMER
 
 #ifdef NS_EVENTLOOP_USE_TICK_TIMER
 /**

--- a/nanostack-event-loop/platform/eventloop_config.h
+++ b/nanostack-event-loop/platform/eventloop_config.h
@@ -17,9 +17,15 @@
 #define EVENTLOOP_CONFIG_H_
 
 /*
- * Undefine all internal flags before evaluating the configuration
+ * Options can be picked up from mbed-cli JSON configuration, or from
+ * Yotta JSON configuration, or from a user configuration file - see below.
+ *
+ * Undefine all internal flags before evaluating the configuration.
  */
+
+/* Use platform-provided low-resolution tick timer for eventloop (requires "platform_tick_timer" API) */
 #undef NS_EVENTLOOP_USE_TICK_TIMER
+/* Exclude high resolution timer from build (removes need for "platform_timer" API) */
 #undef NS_EXCLUDE_HIGHRES_TIMER
 
 /*

--- a/source/ns_timer.h
+++ b/source/ns_timer.h
@@ -16,11 +16,17 @@
 #ifndef NS_TIMER_H_
 #define NS_TIMER_H_
 
+#include "platform/eventloop_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#ifndef NS_EXCLUDE_HIGHRES_TIMER
 extern int8_t ns_timer_sleep(void);
+#else
+#define ns_timer_sleep() ((int8_t) 0)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Make sure we don't try to call ns_timer_sleep() when high-res timers are
excluded.

Clarify options and point out user config file in eventloop_config.h.

Actually exclude prototypes for high-res timer functions from
arm_hal_timer.h when that config flag is set.

Picks up issues arising from discussion of #29 