### PR TITLE
Timeout refactoring

### DIFF
--- a/nanostack-event-loop/eventOS_event.h
+++ b/nanostack-event-loop/eventOS_event.h
@@ -52,6 +52,21 @@ typedef arm_event_t arm_event_s;
 /**
  * \struct arm_event_storage
  * \brief Event structure storage, including list link.
+
+@startuml
+
+partition "Event loop" {
+(*) -->[event created] "UNQUEUED"
+"UNQUEUED" -->[event_core_write()] "QUEUED"
+"QUEUED" -->[event_core_read()] "RUNNING"
+"RUNNING" ->[event_core_free_push()] "UNQUEUED"
+}
+
+partition "system_timer.c" {
+    "UNQUEUED:timer" -->[eventOS_event_send_timer_allocated()] "QUEUED"
+}
+@enduml
+
  */
 typedef struct arm_event_storage {
     arm_event_s data;
@@ -61,6 +76,11 @@ typedef struct arm_event_storage {
         ARM_LIB_EVENT_USER,
         ARM_LIB_EVENT_TIMER,
     } allocator;
+    enum {
+        ARM_LIB_EVENT_UNQUEUED,
+        ARM_LIB_EVENT_QUEUED,
+        ARM_LIB_EVENT_RUNNING,
+    } state;
     ns_list_link_t link;
 } arm_event_storage_t;
 

--- a/source/event.h
+++ b/source/event.h
@@ -20,12 +20,12 @@
 extern "C" {
 #endif
 
+
 bool event_tasklet_handler_id_valid(uint8_t tasklet_id);
 void eventOS_event_send_timer_allocated(arm_event_storage_t *event);
 
-// These require lock to be held
+// This requires lock to be held
 arm_event_storage_t *eventOS_event_find_by_id_critical(uint8_t tasklet_id, uint8_t event_id);
-void eventOS_event_cancel_critical(arm_event_storage_t *event);
 
 #ifdef __cplusplus
 }

--- a/source/timer_sys.h
+++ b/source/timer_sys.h
@@ -20,7 +20,15 @@
 extern "C" {
 #endif
 
-struct arm_event_storage;
+#include "eventOS_event.h"
+
+/* We borrow base event storage, including its list link, and add a time field */
+typedef struct sys_timer_struct_s {
+    arm_event_storage_t event;
+    uint32_t launch_time; // tick value
+    uint32_t period;
+} sys_timer_struct_s;
+
 
 /**
  * Initialize system timer
@@ -31,6 +39,9 @@ extern uint32_t timer_get_runtime_ticks(void);
 int8_t timer_sys_wakeup(void);
 void timer_sys_disable(void);
 void timer_sys_event_free(struct arm_event_storage *event);
+
+// This require lock to be held
+void timer_sys_event_cancel_critical(struct arm_event_storage *event);
 
 /**
  * System Timer update and synch after sleep


### PR DESCRIPTION
## Rework timeout and timer requests.

* Use arm_event_storage_t* as a common return value for timer requests.
* Implement eventOS_cancel(). Cancels any type of event or timer.
* Refactor timeout_* API to use new .._timer_request_at/in() API.
* Add enum to arm_event_storage to allow tracking its state.
* Use this state when cancelling.
* Do not try to cancel timeout types, it is a separate API.
* Use milliseconds instead of ticks in timeout API.
* use eventOS_cancel() from eventOS_timer_cancel().