### PR TITLE
yotta-related fixes

### DIFF
--- a/module.json
+++ b/module.json
@@ -14,9 +14,12 @@
     "nanostack-event-loop"
   ],
   "dependencies": {
-    "nanostack-libservice": "^3.0.0",
-    "mbed-6lowpan-eventloop-adaptor": "^1.0.0",
-    "minar": "^1.0.0"
+    "nanostack-libservice": "ARMmbed/nanostack-libservice#master"
   },
-  "targetDependencies": {}
+  "targetDependencies": {
+    "mbed": {
+      "mbed-6lowpan-eventloop-adaptor": "^1.0.0",
+      "minar": "^1.0.0"
+    }
+  }
 }


### PR DESCRIPTION
1. Don't use mbed-specific dependencies when compiling in Linux.
2. Track the master branch of the dependency rather than a specific
version.

With these changes, this repository can be compiled with yotta in linux:

```
$ yt target x86-linux-gnu
$ yt build
```