### PR TITLE
minar_hal_timer.cpp: Change license header from ARM to APACHE-2.0

### DIFF
--- a/source/minar_hal_timer.cpp
+++ b/source/minar_hal_timer.cpp
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2016 ARM Limited, All Rights Reserved
+ * Copyright (c) 2014-2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // Include before mbed.h to properly get UINT*_C()


### PR DESCRIPTION
I think its just oversight that this one file is ARM licensed?