### PR TITLE
Fix post-event state change for user events

### DIFF
--- a/source/event.c
+++ b/source/event.c
@@ -179,23 +179,25 @@ arm_event_storage_t *event_core_get(void)
 
 void event_core_free_push(arm_event_storage_t *free)
 {
-    free->state = ARM_LIB_EVENT_UNQUEUED;
-
     switch (free->allocator) {
         case ARM_LIB_EVENT_STARTUP_POOL:
+            free->state = ARM_LIB_EVENT_UNQUEUED;
             platform_enter_critical();
             ns_list_add_to_start(&free_event_entry, free);
             platform_exit_critical();
             break;
         case ARM_LIB_EVENT_DYNAMIC:
             // Free all dynamically allocated events.
+            // No need to set state to UNQUEUED - it's being freed.
             ns_dyn_mem_free(free);
             break;
         case ARM_LIB_EVENT_TIMER:
             // Hand it back to the timer system
+            free->state = ARM_LIB_EVENT_UNQUEUED;
             timer_sys_event_free(free);
             break;
         case ARM_LIB_EVENT_USER:
+            // No need set state to UNQUEUED - we forget about it.
         default:
             break;
     }


### PR DESCRIPTION
User-allocated events were marked as UNQUEUED after running. This is
would be incorrect if they were requeued while running, and that is
specifically permitted.

This would not normally cause a problem, but the state is used
in cancel(), so the following sequence would fail:

     Queue user-allocated event       QUEUED
      Event handler runs              RUNNING
       Event handler requeues event   QUEUED
      Event handler exits             UNQUEUED
     Someone cancels event

The event would not get cancelled due it being marked UNQUEUED.

Problem spotted by inspection while discussing using the "state"
variable in user code to check whether a user event was already
queued. This practice remains discouraged, as the arm_event_storage_t
is intended to be opaque, apart from its arm_event_s member.