### PR TITLE
Change event_data to uintptr_t

### DIFF
--- a/nanostack-event-loop/eventOS_event.h
+++ b/nanostack-event-loop/eventOS_event.h
@@ -43,7 +43,7 @@ typedef struct arm_event_s {
     uint8_t event_id; /**< Timer ID, NWK interface ID or application specific ID */
     void *data_ptr; /**< Application could share data pointer tasklet to tasklet */
     arm_library_event_priority_e priority;
-    uint32_t event_data;
+    uintptr_t event_data;
 } arm_event_t;
 
 /* Backwards compatibility */


### PR DESCRIPTION
To aid people who want to pass a second pointer in an event, change `event_data` from `uint32_t` to `uintptr_t`.

This is effectively a null change for 32-bit platforms, but will add 8 bytes to the structure for 64-bit platforms (4 bytes of padding and 4 bytes extra storage), and permit a pointer being stored there.

32-bit platforms might see some compiler warnings from `printf` or similar if `uint32_t` is a different type to `uintptr_t` (`int` versus `long`).

64-bit platforms will see more of a change, but expected problems are minimal - on the whole it will just make 32-bit compatible pointer-smuggling code that failed on 64-bit work.