### PR TITLE
Add Doxygen module documentation for event system.

### DIFF
--- a/nanostack-event-loop/eventOS_event_timer.h
+++ b/nanostack-event-loop/eventOS_event_timer.h
@@ -18,6 +18,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * \file eventOS_event_timer.h
+ * \ingroup nanostack-eventloop
+ * \brief Functions for sending delayed events.
+ */
+
+
 #include "ns_types.h"
 #include "eventOS_event.h"
 

--- a/nanostack-event-loop/eventOS_scheduler.h
+++ b/nanostack-event-loop/eventOS_scheduler.h
@@ -15,10 +15,16 @@
  */
 #ifndef EVENTOS_SCHEDULER_H_
 #define EVENTOS_SCHEDULER_H_
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * \file eventOS_scheduler.h
+ * \ingroup nanostack-eventloop
+ * \brief Event scheduler's control functions.
+ */
+
 #include "ns_types.h"
 
 /* Compatibility with older ns_types.h */


### PR DESCRIPTION
Intent of the Doxygen module page is not to show all scenarios
of the event system, but instead give a brief introduction,
and list the headers that consist of the public API.

Reason for this update is that I'm going to make this visible in the Client Lite API page because the Mbed OS Doxygen does not actually show this. So there is no public Doxygen instance that shows our event loop API, even that it is extensively used in Client Lite. Therefore this deserves its own "module" section there.
